### PR TITLE
chore: use lean-action@v1-alpha

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,23 +5,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: install elan
-        run: |
-          set -o pipefail
-          curl -sSfL https://github.com/leanprover/elan/releases/download/v3.0.0/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-          ./elan-init -y
-          echo "$HOME/.elan/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v4
+      - uses: leanprover/lean-action@v1-alpha
+        with:
+          check-reservoir-eligibility: true
+      # use setup from lean-action to perform the following steps
       - name: print lean and lake versions
         run: |
           lean --version
           lake --version
-      - run: lake build
       - name: verify `lake exe graph` works
         run: |
           lake exe graph
           rm import_graph.dot
-      - name: run tests
-        id: test
-        run: |
-          lake test


### PR DESCRIPTION
Convert existing CI steps to use [`leanprover/lean-action@v1-alpha`](https://github.com/leanprover/lean-action)

I have tested the CI on my fork [here](https://github.com/austinletson/import-graph/actions/runs/9062728704/job/24897201427).

Additional CI features added through `lean-action`:
- `.lake` caching across runs
- [check reservoir eligibility](https://github.com/austinletson/import-graph/actions/runs/9062728704/job/24897201427#step:2:232)

**Note:** two existing CI steps are not covered by `lean-action`: logging versions and verifying `lake exe graph`. Both of these steps are performed after `lean-action` runs, utilizing the elan setup, build, and any `.lake` cache. Therefore, there is a reordering of the existing CI steps.