### PR TITLE
chore: update `lean-action` to v1-beta

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,6 @@ jobs:
         with:
           check-reservoir-eligibility: true
       # use setup from lean-action to perform the following steps
-      - name: print lean and lake versions
-        run: |
-          lean --version
-          lake --version
       - name: verify `lake exe graph` works
         run: |
           lake exe graph

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: leanprover/lean-action@v1-alpha
+      - uses: actions/checkout@v4
+
+      - uses: leanprover/lean-action@v1-beta
         with:
           check-reservoir-eligibility: true
       # use setup from lean-action to perform the following steps


### PR DESCRIPTION
Update `lean-action` to v1-beta and add `actions/checkout` action which is no longer contained in `lean-action`.