### PR TITLE
sort min_imports alphabetically

### DIFF
--- a/ImportGraph/Imports.lean
+++ b/ImportGraph/Imports.lean
@@ -214,8 +214,8 @@ and is not aware of syntax and tactics,
 so the results will likely need to be adjusted by hand.
 -/
 elab "#min_imports" : command => do
-  let imports := (← getEnv).minimalRequiredModules.qsort Name.lt
-    |>.toList.map (fun n => "import " ++ n.toString)
+  let imports := ((← getEnv).minimalRequiredModules.map
+      (fun (n : Name) => n.toString)).qsort  (· < ·) |>.toList.map (fun n => "import " ++ n)
   logInfo <| Format.joinSep imports "\n"
 
 -- deprecated since 2024-07-06


### PR DESCRIPTION
Since there is a call to `qsort` it seems like sorting is intended here. However, currently `qsort` is called on `Name`, but apparently this does not do the correct thing, since when using this in mathlib, I observed that the output was not sorted. We fix this by converting to string earlier and using the `(· < ·)` function to compare the strings.