### PR TITLE
fix: use user's Lean search path in CLI

### DIFF
--- a/ImportGraph/Cli.lean
+++ b/ImportGraph/Cli.lean
@@ -81,7 +81,7 @@ def importGraphCLI (args : Cli.Parsed) : IO UInt32 := do
   let from? := match args.flag? "from" with
   | some fr => some <| fr.as! ModuleName
   | none => none
-  searchPathRef.set compile_time_search_path%
+  initSearchPath (← findSysroot)
 
   let outFiles ← try unsafe withImportModules #[{module := to}] {} (trustLevel := 1024) fun env => do
     let p := ImportGraph.getModule to


### PR DESCRIPTION
Import graph previously encoded the compile-time search path into its executable. This means it would break if run from a different environment or machine. It now uses the information from the user's environment to determine the correct search path, making it reasonably portable.