### PR TITLE
feat: fast unused transitive imports

### DIFF
--- a/ImportGraph/Imports.lean
+++ b/ImportGraph/Imports.lean
@@ -176,15 +176,13 @@ end Lean.NameMap
 Returns a `List (Name × List Name)` with a key for each module `n` in `amongst`,
 whose corresponding value is the list of modules `m` in `amongst` which are transitively imported by `n`,
 but no declaration in `n` makes use of a declaration in `m`.
-
-The current implementation is too slow to run on the entirety of Mathlib,
-although it should be fine for any sequential chain of imports in Mathlib.
 -/
 def unusedTransitiveImports (amongst : List Name) : CoreM (List (Name × List Name)) := do
   let env ← getEnv
   let transitiveImports := env.importGraph.transitiveClosure
+  let transitivelyRequired ← env.transitivelyRequiredModules' amongst
   amongst.mapM fun n => do return (n,
-    let unused := (transitiveImports.find? n).getD {} \ (← env.transitivelyRequiredModules n)
+    let unused := (transitiveImports.find? n).getD {} \ (transitivelyRequired.find? n |>.getD {})
     amongst.filter (fun m => unused.contains m))
 
 /--

--- a/ImportGraph/Imports.lean
+++ b/ImportGraph/Imports.lean
@@ -177,10 +177,10 @@ Returns a `List (Name × List Name)` with a key for each module `n` in `amongst`
 whose corresponding value is the list of modules `m` in `amongst` which are transitively imported by `n`,
 but no declaration in `n` makes use of a declaration in `m`.
 -/
-def unusedTransitiveImports (amongst : List Name) : CoreM (List (Name × List Name)) := do
+def unusedTransitiveImports (amongst : List Name) (verbose : Bool := false) : CoreM (List (Name × List Name)) := do
   let env ← getEnv
   let transitiveImports := env.importGraph.transitiveClosure
-  let transitivelyRequired ← env.transitivelyRequiredModules' amongst
+  let transitivelyRequired ← env.transitivelyRequiredModules' amongst verbose
   amongst.mapM fun n => do return (n,
     let unused := (transitiveImports.find? n).getD {} \ (transitivelyRequired.find? n |>.getD {})
     amongst.filter (fun m => unused.contains m))

--- a/ImportGraph/RequiredModules.lean
+++ b/ImportGraph/RequiredModules.lean
@@ -119,12 +119,14 @@ def Environment.transitivelyRequiredModules (env : Environment) (module : Name) 
 Computes all the modules transitively required by the specified modules.
 Should be equivalent to calling `transitivelyRequiredModules` on each module, but shares more of the work.
 -/
-partial def Environment.transitivelyRequiredModules' (env : Environment) (modules : List Name) :
+partial def Environment.transitivelyRequiredModules' (env : Environment) (modules : List Name) (verbose : Bool := false) :
     CoreM (NameMap NameSet) := do
   let N := env.header.moduleNames.size
   let mut c2m : NameMap (BitVec N) := {}
   let mut result : NameMap NameSet := {}
   for m in modules do
+    if verbose then
+      IO.println s!"Processing module {m}"
     let mut r : BitVec N := 0
     for n in env.header.moduleData[(env.header.moduleNames.getIdx? m).getD 0]!.constNames do
       -- This is messy: Mathlib is big enough that writing a recursive function causes a stack overflow.

--- a/ImportGraph/UnusedTransitiveImports.lean
+++ b/ImportGraph/UnusedTransitiveImports.lean
@@ -1,0 +1,23 @@
+import ImportGraph.Imports
+
+open Lean
+
+def Core.withImportModules (modules : Array Name) {α} (f : CoreM α) : IO α := do
+  searchPathRef.set compile_time_search_path%
+  unsafe Lean.withImportModules (modules.map (fun m => {module := m})) {} (trustLevel := 1024)
+    fun env => Prod.fst <$> Core.CoreM.toIO
+        (ctx := { fileName := "<CoreM>", fileMap := default }) (s := { env := env }) do f
+
+/--
+`lake exe unused_transitive_imports m1 m2 ...`
+
+For each specified module `m`, prints those `n` from the argument list which are imported, but transitively unused by `m`.
+-/
+def main (args : List String) : IO UInt32 := do
+  let (flags, args) := args.partition (fun s => s.startsWith "-")
+  let mut modules := args.map (fun s => s.toName)
+  Core.withImportModules modules.toArray do
+    let r ← unusedTransitiveImports modules (verbose := flags.contains "-v" || flags.contains "--verbose")
+    for (n, u) in r do
+      IO.println s!"{n}: {u}"
+    return 0

--- a/ImportGraphTest/Imports.lean
+++ b/ImportGraphTest/Imports.lean
@@ -1,5 +1,6 @@
 import ImportGraph.Imports
 import ImportGraph.RequiredModules
+import ImportGraphTest.Used
 
 open Lean
 
@@ -36,6 +37,7 @@ elab "#unused_transitive_imports" names:ident* : command => do
     logInfo <| s!"Transitively unused imports of {n}:\n{"\n".intercalate (u.map (fun i => s!"  {i}"))}"
 
 -- This test case can be removed after nightly-2024-10-24, because these imports have been cleaned up.
+-- It should be replaced with another test case!
 /--
 info: Transitively unused imports of Init.Control.StateRef:
   Init.System.IO
@@ -45,6 +47,13 @@ info: Transitively unused imports of Init.System.IO:
 -/
 #guard_msgs in
 #unused_transitive_imports Init.Control.StateRef Init.System.IO Init.Control.Reader Init.Control.Basic
+
+/--
+info: Transitively unused imports of ImportGraphTest.Used:
+  ImportGraphTest.Unused
+-/
+#guard_msgs in
+#unused_transitive_imports ImportGraphTest.Used ImportGraphTest.Unused Init.Control.Reader
 
 -- This is a spurious unused transitive import, because it relies on notation from `Init.Core`.
 /--

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ There are a few commands implemented, which help you analysing the imports of a 
   (Must be run at the end of the file. Tactics and macros may result in incorrect output.)
 * `#find_home decl`: suggests files higher up the import hierarchy to which `decl` could be moved.
 
+## Other executables
+
+`lake exe unused_transitive_imports m1 m2 ...`
+
+For each specified module `m`, prints those `n` from the argument list which are imported, but transitively unused by `m`.
+
 ## Installation
 
 The installation works exactly like for any [Lake package](https://reservoir.lean-lang.org/),

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -28,5 +28,12 @@ root = "Main"
 # Remove this line if you do not need such functionality.
 supportInterpreter = true
 
+# `lake exe unused_transitive_imports` prints unused transitive imports from amongst a given list of modules.
+[[lean_exe]]
+name = "unused_transitive_imports"
+root = "ImportGraph.UnusedTransitiveImports"
+supportInterpreter = true
+
 [[lean_lib]]
 name = "ImportGraphTest"
+


### PR DESCRIPTION
This shares the work required to calculate the unused transitive imports of many modules at once. We need to use `BitVec` to represent subsets of modules (`NameSet` is too slow), and to avoid stack overflows we need to manage the stack manually.