### PR TITLE
fix: run `Lean.enableInitializersExecution` before importing modules

### DIFF
--- a/ImportGraph/Cli.lean
+++ b/ImportGraph/Cli.lean
@@ -85,6 +85,7 @@ def importGraphCLI (args : Cli.Parsed) : IO UInt32 := do
   | none => none
   initSearchPath (← findSysroot)
 
+  Lean.enableInitializersExecution
   let outFiles ← try unsafe withImportModules (to.map ({module := ·})) {} (trustLevel := 1024) fun env => do
     let toModule := ImportGraph.getModule to[0]!
     let mut graph := env.importGraph

--- a/ImportGraph/Cli.lean
+++ b/ImportGraph/Cli.lean
@@ -85,7 +85,7 @@ def importGraphCLI (args : Cli.Parsed) : IO UInt32 := do
   | none => none
   initSearchPath (← findSysroot)
 
-  Lean.enableInitializersExecution
+  unsafe Lean.enableInitializersExecution
   let outFiles ← try unsafe withImportModules (to.map ({module := ·})) {} (trustLevel := 1024) fun env => do
     let toModule := ImportGraph.getModule to[0]!
     let mut graph := env.importGraph


### PR DESCRIPTION
This is needed by https://github.com/leanprover-community/mathlib4/pull/17732.

We should wait to see how https://github.com/leanprover-community/batteries/pull/1047 is resolved first.