### PR TITLE
fix: avoid using compile_time_search_path%

### DIFF
--- a/ImportGraph/Imports.lean
+++ b/ImportGraph/Imports.lean
@@ -188,7 +188,7 @@ def unusedTransitiveImports (amongst : List Name) (verbose : Bool := false) : Co
     amongst.filter (fun m => unused.contains m))
 
 def Core.withImportModules (modules : Array Name) {α} (f : CoreM α) : IO α := do
-  searchPathRef.set compile_time_search_path%
+  initSearchPath (← findSysroot)
   unsafe Lean.withImportModules (modules.map (fun m => {module := m})) {} (trustLevel := 1024)
     fun env => Prod.fst <$> Core.CoreM.toIO
         (ctx := { fileName := "<CoreM>", fileMap := default }) (s := { env := env }) do f


### PR DESCRIPTION
The [docs for compile_time_search_path%](https://leanprover-community.github.io/mathlib4_docs/Lean/Util/SearchPath.html) say that it "must not be used in files that are potentially compiled on another machine and then imported. (That is, if used in an imported file it will embed the search path from whichever machine compiled the .olean.)". This is causing some of the issues described in https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60lake.20build.60.20work.20after.20a.20successful.20.60lake.20exe.20cache.20get.60. See also #35.

Disclaimer: This compiles, but I am not a user of this package and therefore do not know how to test it effectively. Please review carefully.