### PR TITLE
chore: remove unneeded experimental.module option

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -6,9 +6,6 @@ licenseFiles = ["LICENSE"]
 defaultTargets = ["ImportGraph", "graph"]
 testRunner = "ImportGraphTest"
 
-[leanOptions]
-experimental.module = true
-
 [[require]]
 name = "Cli"
 scope = "leanprover"


### PR DESCRIPTION
The `experimental.module` option is no longer necessary with v4.27.0-rc1.