### PR TITLE
fix: filter all `Init` imports in `findImportsFromSource`

### DIFF
--- a/ImportGraph/Imports/FromSource.lean
+++ b/ImportGraph/Imports/FromSource.lean
@@ -33,8 +33,11 @@ Note: This only sees syntactic imports in the source file.
 It does not account for what declarations are actually used.
 -/
 public def findImportsFromSource (path : System.FilePath) : IO (Array Name) := do
+  -- Note: we use `filter` rather than `erase`, since module-system files may contain
+  -- both an implicit `public import Init` and a `meta import Init`, so `Init` can
+  -- appear more than once in the parsed imports.
   return (← Lean.parseImports' (← IO.FS.readFile path) path.toString).imports
-    |>.map (·.module) |>.erase `Init
+    |>.map (·.module) |>.filter (· != `Init)
 
 /--
 Compute the transitive closure of imports starting from a source file.


### PR DESCRIPTION
Module-system files may contain both an implicit \`public import Init\` and a \`meta import Init\`, so \`Lean.parseImports'\` can return \`Init\` more than once. The previous implementation used \`.erase\`, which only drops the first occurrence, letting a stray \`Init\` leak out as a "module" to callers.

This broke mathlib's \`lint-style\` CI job on \`nightly-testing\`: when processing \`Mathlib.lean\`, the surviving \`Init\` was treated as a module to lint, and opening \`Init.lean\` (relative path) failed with \`uncaught exception: no such file or directory ... file: Init.lean\`.

Switching to \`.filter (· != \`Init)\` removes all occurrences and is robust against future changes to how \`parseImports'\` reports the prelude import.

🤖 Prepared with Claude Code