### PR TITLE
fix: correct deprecation warning module name in `ImportGraph.Meta`

### DIFF
--- a/ImportGraph/Meta.lean
+++ b/ImportGraph/Meta.lean
@@ -7,4 +7,4 @@ open Lean
 
 -- deprecated 2026-02-01
 #eval do
-  logWarning "`ImportGraph.Imports` is deprecated! use `import ImportGraph.Tools` instead."
+  logWarning "`ImportGraph.Meta` is deprecated! use `import ImportGraph.Tools` instead."


### PR DESCRIPTION
The deprecation warning emitted from `ImportGraph.Meta` mistakenly names `ImportGraph.Imports` as the deprecated module — apparently copy-pasted from the sibling shim in `ImportGraph/Imports.lean`.

Refs: #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)